### PR TITLE
0.6.3

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -55,21 +55,12 @@ jobs:
         env:
           npm_config_arch: ${{ matrix.arch }}
 
-      - name: Upload artifacts (x64)
+      - name: Upload artifacts (x64, arm64)
         if: matrix.arch == 'x64'
         uses: actions/upload-artifact@v4
         with:
-          name: mac-${{ matrix.arch }}
+          name: mac-x64-arm64
           path: |
             release/build/vde-dataset-viewer-[0-9]*.[0-9]*.[0-9]*.dmg
             release/build/vde-dataset-viewer-[0-9]*.[0-9]*.[0-9]*.dmg.blockmap
             release/build/latest-mac.yml
-
-      - name: Upload artifacts (arm64)
-        if: matrix.arch == 'arm64'
-        uses: actions/upload-artifact@v4
-        with:
-          name: mac-${{ matrix.arch }}
-          path: |
-            release/build/vde-dataset-viewer-[0-9]*.[0-9]*.[0-9]*-arm64.dmg
-            release/build/vde-dataset-viewer-[0-9]*.[0-9]*.[0-9]*-arm64.dmg.blockmap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.6.3
+### Improvements
+* Improved handling of invalid Define-XML files and adding Open File button to the Define-XML screen [#92](https://github.com/defineEditor/vde-dataset-viewer/issues/92)
+
+### Fixes
+* Fix TIG substandard selection for CORE 0.14 [#90](https://github.com/defineEditor/vde-dataset-viewer/issues/90)
+* Drag and dropping SAS7BDAT does not open the dataset  [#91](https://github.com/defineEditor/vde-dataset-viewer/issues/91)
+
 # 0.6.2
 ### Core Changes
 * Render Define-XML 2.0 and 2.1 in a format similar to the stylesheet [#83](https://github.com/defineEditor/vde-dataset-viewer/issues/83)

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vde-dataset-viewer",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "VDE Dataset Viewer",
   "license": "MIT",
   "author": {

--- a/src/interfaces/electron.api.d.ts
+++ b/src/interfaces/electron.api.d.ts
@@ -100,7 +100,9 @@ export interface ElectronApi {
         props?: NewWindowProps,
     ) => Promise<void>;
     openDefineXml: (filePath?: string) => Promise<DefineFileInfo | null>;
-    getDefineXmlContent: (fileId: string) => Promise<DefineXmlContent | null>;
+    getDefineXmlContent: (
+        fileId: string,
+    ) => Promise<DefineXmlContent | { error: string }>;
     closeDefineXml: (fileId: string) => Promise<boolean>;
     isWindows: boolean;
     resizeWindow: (

--- a/src/main/managers/defineXmlManager.ts
+++ b/src/main/managers/defineXmlManager.ts
@@ -192,26 +192,35 @@ class DefineXmlManager {
     public getDefineXmlContent = async (
         _event: IpcMainInvokeEvent,
         fileId: string,
-    ): Promise<DefineXmlContent> => {
+    ): Promise<DefineXmlContent | { error: string }> => {
         const fileInfo = this.openedXmlFiles[fileId];
         if (!fileInfo) {
-            throw new Error(`Define file not found for ID: ${fileId}`);
+            return { error: `Define file not found for ID: ${fileId}` };
         }
 
-        const xmlContent = await fsPromises.readFile(fileInfo.fullPath, 'utf8');
+        try {
+            const xmlContent = await fsPromises.readFile(
+                fileInfo.fullPath,
+                'utf8',
+            );
 
-        // Parse XML content
-        const parsedXml = await parseDefineXml(
-            xmlContent,
-            fileInfo.defineVersion,
-            fileInfo.arm,
-        );
-        return {
-            defineVersion: fileInfo.defineVersion,
-            arm: fileInfo.arm,
-            type: 'xml',
-            content: parsedXml,
-        };
+            // Parse XML content
+            const parsedXml = await parseDefineXml(
+                xmlContent,
+                fileInfo.defineVersion,
+                fileInfo.arm,
+            );
+            return {
+                defineVersion: fileInfo.defineVersion,
+                arm: fileInfo.arm,
+                type: 'xml',
+                content: parsedXml,
+            };
+        } catch (error) {
+            return {
+                error: `Error reading/parsing Define-XML: ${error instanceof Error ? error.message : String(error)}`,
+            };
+        }
     };
 
     /**

--- a/src/renderer/components/DefineXmlStylesheet/index.tsx
+++ b/src/renderer/components/DefineXmlStylesheet/index.tsx
@@ -139,7 +139,6 @@ const DefineXml: React.FC = () => {
                         }),
                     );
                     dispatch(setDefineFileId(null));
-                    dispatch(setDefineIsLoading(false));
                     return;
                 }
                 setContent(defineContent);
@@ -149,6 +148,9 @@ const DefineXml: React.FC = () => {
         if (currentFileId) {
             dispatch(setDefineIsLoading(true));
             fetchDefineContent();
+        } else {
+            setContent(null);
+            dispatch(setDefineIsLoading(false));
         }
     }, [currentFileId, apiService, dispatch]);
 
@@ -174,7 +176,7 @@ const DefineXml: React.FC = () => {
                     <Button sx={styles.openButton} onClick={handleOpenDefine}>
                         Open file
                     </Button>
-                    <Box>or drag and drop it here a Define-XML</Box>
+                    <Box>or drag and drop a Define-XML here</Box>
                 </Stack>
             </Box>
         );

--- a/src/renderer/components/DragAndDrop/index.tsx
+++ b/src/renderer/components/DragAndDrop/index.tsx
@@ -46,6 +46,7 @@ const DragAndDrop: React.FC<Props> = ({ children }) => {
                 fileExtension === 'xpt' ||
                 fileExtension === 'json' ||
                 fileExtension === 'ndjson' ||
+                fileExtension === 'sas7bdat' ||
                 fileExtension === 'dsjc'
             ) {
                 const newDataInfo = await openNewDataset(

--- a/src/renderer/components/Validator/Configuration.tsx
+++ b/src/renderer/components/Validator/Configuration.tsx
@@ -90,11 +90,17 @@ const ValidatorConfiguration: React.FC<ValidatorConfigurationProps> = ({
         } = {};
         validatorData.info.standards.forEach((rawStandard) => {
             const parsedStandard = rawStandard.split(',');
-            const [name, version] = parsedStandard;
+            const [name, version, substandard] = parsedStandard;
+            const versionWithSubstandard = substandard
+                ? `${version},${substandard}`
+                : version;
             if (!standards[name]) {
-                standards[name] = { name, versions: [version] };
+                standards[name] = {
+                    name,
+                    versions: [versionWithSubstandard],
+                };
             } else {
-                standards[name].versions.push(version);
+                standards[name].versions.push(versionWithSubstandard);
             }
         });
         return standards;

--- a/src/renderer/services/ApiService.ts
+++ b/src/renderer/services/ApiService.ts
@@ -904,13 +904,16 @@ class ApiService {
 
     public getDefineXmlContent = async (
         fileId: string,
-    ): Promise<DefineXmlContent | null> => {
+    ): Promise<DefineXmlContent | { error: string }> => {
         // Check if the content is already loaded
         if (this.openedDefineContents[fileId] !== undefined) {
             return this.openedDefineContents[fileId];
         }
         const content = await window.electron.getDefineXmlContent(fileId);
         if (content !== null) {
+            if ('error' in content) {
+                return content;
+            }
             this.openedDefineContents[fileId] = content;
         }
         return content;

--- a/src/renderer/services/ApiService.ts
+++ b/src/renderer/services/ApiService.ts
@@ -910,12 +910,10 @@ class ApiService {
             return this.openedDefineContents[fileId];
         }
         const content = await window.electron.getDefineXmlContent(fileId);
-        if (content !== null) {
-            if ('error' in content) {
-                return content;
-            }
-            this.openedDefineContents[fileId] = content;
+        if ('error' in content) {
+            return content;
         }
+        this.openedDefineContents[fileId] = content;
         return content;
     };
 


### PR DESCRIPTION
# 0.6.3
### Improvements
* Improved handling of invalid Define-XML files and adding Open File button to the Define-XML screen [#92](https://github.com/defineEditor/vde-dataset-viewer/issues/92)

### Fixes
* Fix TIG substandard selection for CORE 0.14 [#90](https://github.com/defineEditor/vde-dataset-viewer/issues/90)
* Drag and dropping SAS7BDAT does not open the dataset  [#91](https://github.com/defineEditor/vde-dataset-viewer/issues/91)
